### PR TITLE
fix: duplicate content caused by reinstallation

### DIFF
--- a/scripts/xray_script/Install_server_with_xray.sh
+++ b/scripts/xray_script/Install_server_with_xray.sh
@@ -105,7 +105,7 @@ get_latest_version() {
 }
 makeConfig() {
   mkdir -p /usr/lib/systemd/system/
-  cat >>/usr/local/etc/au/au.json <<EOF
+  cat >/usr/local/etc/au/au.json <<EOF
 {
   "panel": {
     "type": "${panelType}",
@@ -124,7 +124,7 @@ EOF
 }
 
 createService() {
-  cat >>/usr/lib/systemd/system/au.service <<EOF
+  cat >/usr/lib/systemd/system/au.service <<EOF
 [Unit]
 Description=Air-Universe - main Service
 After=network.target


### PR DESCRIPTION
意外安装失败以后，再次运行安装脚本会导致配置文件内容重复